### PR TITLE
Fix category filtering bug

### DIFF
--- a/django/coolsite/test_app/templatetags/test_app_tags.py
+++ b/django/coolsite/test_app/templatetags/test_app_tags.py
@@ -8,7 +8,7 @@ def get_categories(filter=None):
     if not filter:
         return Category.objects.all()
     else:
-        return Category.objects.all(pk=filter)
+        return Category.objects.filter(pk=filter)
 
 
 @register.inclusion_tag('test_app/list_categories.html')


### PR DESCRIPTION
## Summary
- fix erroneous `Category.objects.all(pk=...)` call in `get_categories` template tag

## Testing
- `python django/coolsite/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686168d2330c832b8f4959b4853e0c16