### PR TITLE
Enable post deletion by authors

### DIFF
--- a/django/coolsite/test_app/templates/test_app/post.html
+++ b/django/coolsite/test_app/templates/test_app/post.html
@@ -53,6 +53,12 @@
             👎 Дизлайк ({{ post.dislikes }})
         </button>
     </form>
+    {% if user == post.author %}
+    <form action="{% url 'delete_post' post_slug=post.slug %}" method="POST" style="display: inline;">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-warning">Видалити пост</button>
+    </form>
+    {% endif %}
 </div>
 
 <h3>Залишити коментар</h3>

--- a/django/coolsite/test_app/urls.py
+++ b/django/coolsite/test_app/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('logout/', LogoutUser, name='logout_user'),
     path('python/',  Python.as_view(), name='python'),
     path('post/<slug:post_slug>/', ShowPost.as_view(), name='post'),
+    path('post/<slug:post_slug>/delete/', DeletePost.as_view(), name='delete_post'),
     path('category/<slug:cat_slug>/', ShowCategory.as_view(), name='category'),
     path('add_page/', AddPage.as_view(), name='add_page'),
     path('help/', Help.as_view(), name='help'),

--- a/django/coolsite/test_app/views.py
+++ b/django/coolsite/test_app/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth import logout, login
 from django.contrib.auth.views import LoginView
 from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse_lazy
-from django.views.generic import ListView, DetailView, CreateView, FormView
+from django.views.generic import ListView, DetailView, CreateView, FormView, View
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.edit import FormMixin
 from django.contrib.auth.decorators import login_required
@@ -14,6 +14,7 @@ from django.contrib.auth import update_session_auth_hash
 from django.shortcuts import render
 from django.views.generic import TemplateView
 from django.shortcuts import render
+from django.http import HttpResponseForbidden
 
 from rest_framework.response import *
 from rest_framework.views import *
@@ -69,6 +70,17 @@ class AddPage(LoginRequiredMixin, DataMixin, CreateView):
         context=super().get_context_data(**kwargs)
         c_def=self.get_user_context(title="Добавлення статті")
         return dict(list(context.items())+list(c_def.items()))
+
+
+class DeletePost(LoginRequiredMixin, View):
+    """Delete a post if the request user is the author."""
+
+    def post(self, request, post_slug):
+        post = get_object_or_404(library, slug=post_slug)
+        if post.author != request.user:
+            return HttpResponseForbidden()
+        post.delete()
+        return redirect('python')
     
 
 class ShowPost(DataMixin, FormMixin, DetailView):


### PR DESCRIPTION
## Summary
- allow authors to delete their own posts
- expose delete route
- show delete button on the post page

## Testing
- `python django/coolsite/manage.py check`
- `python django/coolsite/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686e4ea9fb28832bbdd82ef57857103b